### PR TITLE
Minor fixes

### DIFF
--- a/templates/prefix.html
+++ b/templates/prefix.html
@@ -44,8 +44,8 @@ td { white-space: nowrap; }
             <div class="col-md-7">
                 <div class="row">&nbsp;
                 </div>
-                <form id="form">
-                    <h2>Prefix</h2><input type="text" name="prefix"/>
+                <form id="form" class="form-inline">
+                    <h2>Prefix</h2><input type="text" name="prefix" class="form-control" />
                     <button id="btnsearch" type="submit" class="btn btn-primary" name="search" value="Search">Search</button>
                 </form>
             </div>
@@ -85,6 +85,30 @@ td { white-space: nowrap; }
 {{super()}}
 <script type="text/javascript" src="//cdn.datatables.net/1.10.7/js/jquery.dataTables.min.js"></script>
 <script type="text/javascript">
+// source: https://github.com/h5bp/html5-boilerplate/blob/master/src/js/plugins.js
+// Avoid `console` errors in browsers that lack a console.
+(function() {
+    var method;
+    var noop = function () {};
+    var methods = [
+        'assert', 'clear', 'count', 'debug', 'dir', 'dirxml', 'error',
+        'exception', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log',
+        'markTimeline', 'profile', 'profileEnd', 'table', 'time', 'timeEnd',
+        'timeline', 'timelineEnd', 'timeStamp', 'trace', 'warn'
+    ];
+    var length = methods.length;
+    var console = (window.console = window.console || {});
+
+    while (length--) {
+        method = methods[length];
+
+        // Only stub undefined methods.
+        if (!console[method]) {
+            console[method] = noop;
+        }
+    }
+}());
+
 $(document).ready(function () {
 
     // look at what is after /prefix/ in the URL
@@ -153,9 +177,9 @@ function rendererImgFunction(data, alldata, fieldname, prefix) {
     if (typeof data != 'undefined') {
         switch (data.toString()) {
             case "true":
-                return "<img src='/static/img/true.png'>";
+                return "<img alt='T' title='True' src='/static/img/true.png'>";
             case "false":
-                return "<img src='/static/img/false.png'>";
+                return "<img alt='F' title='False' src='/static/img/false.png'>";
             default:
                 if (fieldname == "advice") {
                     console.log(alldata['label']);
@@ -164,7 +188,7 @@ function rendererImgFunction(data, alldata, fieldname, prefix) {
                     return "<a href=\"http://lg.ring.nlnog.net/query/" + prefix + "\">" + data + "</a>";
                 }
                 else {
-                    return data;    
+                    return data;
                 }
         }
     } else {
@@ -236,7 +260,7 @@ function populatetable(tblname, prefix_data) {
                 "searching": false,
                 "lengthChange": false,
                 "bPaginate": false
-            } );   
+            } );
     } else {
         // just update, already set the table up once
         $("#example").dataTable().fnClearTable();


### PR DESCRIPTION
Add relevant bootstrap helper classes so input and button are aligned.
Add alt and title attribute to the true/false image, adds accessibility.
Add console wrapper so that browsers that do not have a console dont error on the debugging.

> Note that these are only applied to prefix.html and should be applied to exact_prefix as well, but ideally the console wrapper should be part of your header/footer so you dont have to keep replicating on each page.
