### PR TITLE
re-target prefix query form to /prefix/

### DIFF
--- a/templates/exact_prefix.html
+++ b/templates/exact_prefix.html
@@ -106,7 +106,7 @@ $(document).ready(function () {
 
     $("form").submit(function (e) {
         e.preventDefault(); //prevent default form submit
-        window.location.href = '/exact_prefix/' + $('form').find('input[name="prefix"]').val();
+        window.location.href = '/prefix/' + $('form').find('input[name="prefix"]').val();
         //prefixsearch();
     });
 


### PR DESCRIPTION
Fixes the form target so filling in the form at `/exact_prefix/` takes you back to `/prefix/`.
